### PR TITLE
feat: WordPress 7.0 compatibility (Sage 10)

### DIFF
--- a/resources/styles/back-office/global.css
+++ b/resources/styles/back-office/global.css
@@ -5,12 +5,12 @@
  * d'injection face au color scheme natif.
  */
 .wp-admin {
-    --wp-admin-theme-color: var(--horizon-admin-main-color) !important;
-    --wp-admin-theme-color--rgb: var(--horizon-admin-main-color-rgb) !important;
-    --wp-admin-theme-color-darker-10: var(--horizon-admin-main-color-dark) !important;
-    --wp-admin-theme-color-darker-10--rgb: var(--horizon-admin-main-color-dark-rgb) !important;
-    --wp-admin-theme-color-darker-20: var(--horizon-admin-main-color-dark) !important;
-    --wp-admin-theme-color-darker-20--rgb: var(--horizon-admin-main-color-dark-rgb) !important;
+    --wp-admin-theme-color: var(--horizon-admin-main-color, #2271b1) !important;
+    --wp-admin-theme-color--rgb: var(--horizon-admin-main-color-rgb, 34, 113, 177) !important;
+    --wp-admin-theme-color-darker-10: var(--horizon-admin-main-color-dark, #135e96) !important;
+    --wp-admin-theme-color-darker-10--rgb: var(--horizon-admin-main-color-dark-rgb, 19, 94, 150) !important;
+    --wp-admin-theme-color-darker-20: var(--horizon-admin-main-color-dark, #0a4b78) !important;
+    --wp-admin-theme-color-darker-20--rgb: var(--horizon-admin-main-color-dark-rgb, 10, 75, 120) !important;
 }
 
 .wp-admin {

--- a/resources/styles/back-office/global.css
+++ b/resources/styles/back-office/global.css
@@ -1,3 +1,18 @@
+/*
+ * Catch-all : remappe la variable de couleur de thème WP (utilisée de plus en
+ * plus largement depuis WP 7.0 — page extensions, liserets, focus, etc.) sur la
+ * couleur dérivée du favicon. !important pour gagner quel que soit l'ordre
+ * d'injection face au color scheme natif.
+ */
+.wp-admin {
+    --wp-admin-theme-color: var(--horizon-admin-main-color) !important;
+    --wp-admin-theme-color--rgb: var(--horizon-admin-main-color-rgb) !important;
+    --wp-admin-theme-color-darker-10: var(--horizon-admin-main-color-dark) !important;
+    --wp-admin-theme-color-darker-10--rgb: var(--horizon-admin-main-color-dark-rgb) !important;
+    --wp-admin-theme-color-darker-20: var(--horizon-admin-main-color-dark) !important;
+    --wp-admin-theme-color-darker-20--rgb: var(--horizon-admin-main-color-dark-rgb) !important;
+}
+
 .wp-admin {
     #adminmenu {
         li.wp-has-current-submenu {

--- a/src/Blocks/AbstractBlock.php
+++ b/src/Blocks/AbstractBlock.php
@@ -71,6 +71,8 @@ abstract class AbstractBlock
             'customClassName' => true,
             'jsx' => false,
             'renaming' => false,
+            // Désactive le champ « CSS additionnel » par bloc ajouté par WordPress 7.0.
+            'customCSS' => false,
         ];
     }
 

--- a/src/Hooks/DefaultWordPressHooks.php
+++ b/src/Hooks/DefaultWordPressHooks.php
@@ -34,6 +34,8 @@ class DefaultWordPressHooks extends AbstractHook
             ['wp_enqueue_scripts', [$this, 'removeWordPressCoreStyle'], 100, 1],
             ['wp_enqueue_scripts', [$this, 'handleAdminBarStyles'], 10, 1],
             ['admin_init', [$this, 'disabledCustomThemes'], 10, 0],
+            ['admin_menu', [$this, 'removeFontLibraryMenu'], 999, 0],
+            ['admin_init', [$this, 'blockFontLibraryAccess'], 10, 0],
         ];
 
         if (SearchEngineService::isSearchEngineEnabled()) {
@@ -316,6 +318,8 @@ EOF;
                 $styleVars['horizon-admin-main-color'] = $mainColor;
                 $styleVars['horizon-admin-main-color-light'] = $mainColorLight;
                 $styleVars['horizon-admin-main-color-dark'] = $mainColorDark;
+                $styleVars['horizon-admin-main-color-rgb'] = ColorService::hexToRgb($mainColor);
+                $styleVars['horizon-admin-main-color-dark-rgb'] = ColorService::hexToRgb($mainColorDark);
                 $styleVars['horizon-admin-box-shadow'] = $boxShadow;
             }
         }
@@ -349,6 +353,27 @@ EOF;
             $styleContent .= $adminStyle;
 
             echo sprintf('<style>%s%s</style>', $this->getStyleVars(), $styleContent);
+        }
+    }
+
+    /**
+     * Retire l'entrée de menu « Polices » (Font Library, WP 7.0) sous Apparence.
+     */
+    public static function removeFontLibraryMenu(): void
+    {
+        remove_submenu_page('themes.php', 'font-library.php');
+    }
+
+    /**
+     * Bloque l'accès direct à la Font Library par URL (wp-admin/font-library.php).
+     */
+    public static function blockFontLibraryAccess(): void
+    {
+        global $pagenow;
+
+        if ('font-library.php' === $pagenow) {
+            wp_safe_redirect(admin_url());
+            exit;
         }
     }
 

--- a/src/Services/ColorService.php
+++ b/src/Services/ColorService.php
@@ -29,6 +29,23 @@ class ColorService
         return '#' . implode($hexCode);
     }
 
+    /**
+     * Convert a hex color (#rgb or #rrggbb) into a "r, g, b" triplet string,
+     * usable inside rgba(var(--…--rgb), a) like WordPress' --wp-admin-theme-color--rgb.
+     */
+    public static function hexToRgb(string $hexCode): string
+    {
+        $hexCode = ltrim($hexCode, '#');
+
+        if (strlen($hexCode) == 3) {
+            $hexCode = $hexCode[0] . $hexCode[0] . $hexCode[1] . $hexCode[1] . $hexCode[2] . $hexCode[2];
+        }
+
+        [$r, $g, $b] = array_map('hexdec', str_split($hexCode, 2));
+
+        return sprintf('%d, %d, %d', $r, $g, $b);
+    }
+
     public static function getSiteMainColorFromIcon(bool $useCache = true): ?string
     {
         if ($useCache) {


### PR DESCRIPTION
## Objectif

Adapter horizon-tools aux nouveautés de **WordPress 7.0** pour la base **Sage 10**, sans casser les sites en WP < 7 (les fonctions appelées sont antérieures à WP 7, et les nouveautés WP 7 absentes sur les anciennes versions sont simplement ignorées).

> Portage des changements de la PR #30 (Sage 11) sur la branche `sage/10`.

## Changements

### Back-office
- **Remap de la couleur de thème admin** sur la couleur dérivée du favicon. `--wp-admin-theme-color` est désormais utilisé bien plus largement dans WP 7.0 (page extensions, liserets, focus, accents). Ajout de `ColorService::hexToRgb()` et des variables `--horizon-admin-main-color-rgb` / `-dark-rgb` (injectées via `getStyleVars()`), remappées via `global.css` (`!important` pour gagner face au color scheme natif).
- **Suppression de la Font Library** (WP 7.0) : retrait de l'entrée de menu « Polices » sous Apparence et blocage de l'accès direct à `wp-admin/font-library.php` (redirection).

### Éditeur de blocs
- **Désactivation du champ « CSS additionnel » par bloc** introduit par WP 7.0 (`'customCSS' => false` dans les supports par défaut de `AbstractBlock`).

## Compatibilité WP < 7

✅ Aucun fatal ni régression :
- `customCSS` : clé de `supports` inconnue → ignorée silencieusement.
- `remove_submenu_page('themes.php', 'font-library.php')` : no-op si le sous-menu n'existe pas.
- `blockFontLibraryAccess` : `$pagenow === 'font-library.php'` jamais vrai sur WP < 7.
- Remap couleur : CSS pur, `--wp-admin-theme-color` existe depuis WP 5.7.