### PR TITLE
feat(listing): PERIOD filter type + DateQuery re-export

### DIFF
--- a/src/Database/DateQuery.php
+++ b/src/Database/DateQuery.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Adeliom\HorizonTools\Database;
+
+use Adeliom\HorizonQueryBuilder\Database\DateQuery as HorizonDateQuery;
+
+class DateQuery extends HorizonDateQuery
+{
+}

--- a/src/Enum/FilterTypesEnum.php
+++ b/src/Enum/FilterTypesEnum.php
@@ -9,4 +9,5 @@ enum FilterTypesEnum: string
     case TAXONOMY = 'taxonomy';
     case META = 'meta';
     case SEARCH = 'search';
+    case PERIOD = 'period';
 }


### PR DESCRIPTION
## What

Add `FilterTypesEnum::PERIOD` and a thin `Adeliom\HorizonTools\Database\DateQuery` re-export.

## Why

Supports the Listing block's new **period (publication-date) filter**. `PERIOD` is a new filter type (like `SEARCH`); the `DateQuery` re-export follows the existing `MetaQuery`/`TaxQuery` pattern so consumers import from the `HorizonTools\Database` namespace.

## Changes

- `src/Enum/FilterTypesEnum.php` — add `case PERIOD = 'period';`.
- `src/Database/DateQuery.php` — `class DateQuery extends Adeliom\HorizonQueryBuilder\Database\DateQuery {}`.

Depends on horizon-querybuilder's `DateQuery` (merge that first). Part of a 3-package feature; cross-repo final review: Ready to merge.
