### PR TITLE
fix(list:blocks): read the block title through getTitle()

### DIFF
--- a/src/Console/Commands/ListBlocks.php
+++ b/src/Console/Commands/ListBlocks.php
@@ -20,7 +20,10 @@ class ListBlocks extends Command
 
         foreach (ClassService::getAllCustomBlockClasses() as $blockClass) {
             $slug = $blockClass::$slug;
-            $title = $blockClass::$title;
+            // getTitle() and not the $title property: blocks are free to override the getter to
+            // return a translated title, and AbstractBlock::getTitle() falls back to $title
+            // anyway. Reading the property left every such block listed without a name.
+            $title = $blockClass::getTitle();
 
             $data[] = [$title, $slug, $blockClass];
         }


### PR DESCRIPTION
`list:blocks` read the `$title` property directly, so every block that overrides `getTitle()` to return a translated title was listed without a name. That is the case for **all the blocks shipped by horizon-blocks** — accordion, argument, customer-review, form, listing, photo-carousel, steps, title-text all showed an empty first column.

Gutenberg was never affected: `BlockServiceProvider` already calls `getTitle()`.

`AbstractBlock::getTitle()` returns `$title` by default, so blocks that only set the property keep working unchanged.

Found while integrating the listing block on a project, where the workaround was to set `$title` on all eight blocks — this one line makes that unnecessary for every Horizon project.
