### PR TITLE
feat(gutenberg): disable the block directory in the inserter

### DIFF
--- a/src/Hooks/DefaultGutenbergHooks.php
+++ b/src/Hooks/DefaultGutenbergHooks.php
@@ -13,6 +13,24 @@ class DefaultGutenbergHooks extends AbstractHook
     public function init(): void
     {
         add_filter('block_editor_settings_all', [$this, 'injectEditorStyles']);
+
+        if (!Config::get('gutenberg.block_directory', false)) {
+            $this->disableBlockDirectory();
+        }
+    }
+
+    /**
+     * Remove the Block Directory from the block inserter.
+     *
+     * Without it, searching in the inserter lists plugins to install from
+     * wordpress.org next to the site's own blocks — never desirable on a
+     * project where the available blocks are the ones we ship.
+     *
+     * Re-enable per project via Config::set('gutenberg.block_directory', true).
+     */
+    public function disableBlockDirectory(): void
+    {
+        remove_action('enqueue_block_editor_assets', 'wp_enqueue_editor_block_directory_assets');
     }
 
     /**


### PR DESCRIPTION
## Contexte

En cherchant un bloc dans l'inserteur Gutenberg, WordPress affiche sous les blocs du site une section « Disponible(s) pour l'installation » listant des plugins de wordpress.org (Lightbox Block, Algori Social Share…). Sur un projet Adeliom, les blocs disponibles sont ceux qu'on livre : cette section n'a jamais de raison d'être.

## Changement

`DefaultGutenbergHooks::init()` retire désormais `wp_enqueue_editor_block_directory_assets` de `enqueue_block_editor_assets`.

Le comportement est piloté par une clé de config, dans la lignée de `gutenberg.styles` déjà lue par `injectEditorStyles` :

```php
// config/gutenberg.php d'un projet, pour rétablir le Block Directory
return [
    'block_directory' => true,
];
```

Défaut : `false` (Block Directory désactivé).

## Test

Vérifié sur l'install Vénus (fichier du package copié dans `vendor/`) :

| Config | `has_action('enqueue_block_editor_assets', 'wp_enqueue_editor_block_directory_assets')` |
|---|---|
| défaut | `false` — suggestions retirées |
| `'block_directory' => true` | `10` — suggestions rétablies |