### PR TITLE
fix(summary): skip headings nested in a blockquote

### DIFF
--- a/src/Services/BlogPostService.php
+++ b/src/Services/BlogPostService.php
@@ -239,6 +239,10 @@ class BlogPostService
                 return $headings;
             }
 
+            // Une citation est souvent composée avec un titre pour sa mise en forme : ce n'est pas
+            // une section de l'article, on l'écarte avant de relever les titres.
+            $html = preg_replace(pattern: '#<blockquote\b[^>]*>.*?</blockquote>#is', replacement: '', subject: $html) ?? $html;
+
             // Pattern pour matcher h1 à h6 avec leur contenu
             preg_match_all(pattern: '/<h([1-6])[^>]*>(.*?)<\/h\1>/is', subject: $html, matches: $matches, flags: PREG_SET_ORDER);
 


### PR DESCRIPTION
## Contexte

`BlogPostService::getPostTitlesFromHtmlLogic()` relève les `<h1>`–`<h6>` du HTML rendu de l'article. Dès qu'un projet met autre chose que `h2` dans `TO_RETRIEVE`, les citations remontent dans le sommaire : le rédacteur compose souvent son `<blockquote>` avec un titre pour la mise en forme, alors que ce n'est pas une section de l'article.

Constaté sur Vénus après passage à `TO_RETRIEVE = ['h2', 'h3']` — l'entrée n° 2 du sommaire était le texte de la citation.

## Changement

Les `<blockquote>` sont retirés du HTML avant le relevé des titres :

```php
$html = preg_replace(pattern: '#<blockquote\b[^>]*>.*?</blockquote>#is', replacement: '', subject: $html) ?? $html;
```

Aucun impact sur les projets qui ne collectent que les `h2` : un `h2` dans une citation n'aurait pas eu davantage sa place dans le sommaire.

## Test

Vérifié sur l'install Vénus (fichier du package copié dans `vendor/`), article avec une citation composée d'un `h3` :

| | entrées du sommaire |
|---|---|
| avant | 5, dont le texte de la citation |
| après | 4, uniquement les titres de section |