### PR TITLE
feat(mails): expéditeur global pour les notifications et les e-mails WordPress

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,35 @@ Customize the WordPress admin appearance via `config/back-office.php`:
 - **Confirmation Pages**: Optional post type for Gravity Forms confirmation pages (config-gated).
 - **Optional Labels**: Automatically replaces "nécessaire" with "facultatif" on optional fields.
 - **FormField**: ACF field to select Gravity Forms in your custom fields.
+- **Global Mail Sender**: One sender address and name for every form notification and every WordPress
+  mail, set in Forms > Settings > E-mails (config-gated, off by default).
+
+```php
+// config/gravityforms.php
+return [
+    'sender' => [
+        // Off by default: enabling it changes the sender of existing notifications.
+        'enabled' => true,
+        // Set to false to leave non-Gravity-Forms mails (password reset, WordPress alerts) untouched.
+        'applyToWordPressMails' => true,
+    ],
+];
+```
+
+The setting is a default, never a constraint: it only fills a notification's From Email that is empty
+or still on the `{admin_email}` Gravity Forms puts there, so an address typed into one notification
+always wins. Reply-To is filled the same way, with the visitor's email, on notifications sent to a
+fixed address — never on the ones sent back to the visitor.
+
+A theme that would rather drive the sender from its own options page can skip the Gravity Forms
+screen entirely and answer the `horizon_tools_mail_sender` filter:
+
+```php
+add_filter('horizon_tools_mail_sender', fn (array $sender): array => [
+    'address' => get_field('sender_address', 'option') ?: $sender['address'],
+    'name' => get_field('sender_name', 'option') ?: $sender['name'],
+]);
+```
 
 ### WYSIWYG Customization
 

--- a/src/Hooks/DefaultMailSenderHooks.php
+++ b/src/Hooks/DefaultMailSenderHooks.php
@@ -1,0 +1,346 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Adeliom\HorizonTools\Hooks;
+
+use Adeliom\HorizonTools\Services\MailSenderService;
+use Gravity_Forms\Gravity_Forms\Settings\Settings;
+
+/**
+ * Applique l'expéditeur global (MailSenderService) aux notifications Gravity Forms et aux e-mails
+ * de WordPress, et porte l'écran de réglages où il se saisit.
+ *
+ * Le réglage global est un défaut, pas une contrainte : il ne remplit que les champs laissés vides,
+ * ou laissés sur la valeur que Gravity Forms y place lui-même. Une adresse saisie dans une
+ * notification particulière l'emporte donc toujours, ce qui permet de faire parler un formulaire
+ * d'une autre voix sans réglage supplémentaire à inventer.
+ *
+ * Corollaire assumé de ce choix : `{admin_email}` est indissociable de « non renseigné », puisque
+ * c'est le défaut de Gravity Forms (notification.php). Pour qu'une notification suive explicitement
+ * l'adresse d'administration du site malgré un réglage global, il faut y écrire l'adresse en clair.
+ */
+class DefaultMailSenderHooks extends AbstractHook
+{
+    /** Sous-vue de Formulaires > Réglages qui porte l'écran de saisie. */
+    private const SETTINGS_SUBVIEW = 'horizon-mails';
+
+    /** Valeur que Gravity Forms pré-remplit dans « From Email » à la création d'une notification. */
+    private const GF_DEFAULT_FROM = '{admin_email}';
+
+    /** Nom d'expéditeur que WordPress utilise faute de mieux (pluggable.php). */
+    private const WP_DEFAULT_FROM_NAME = 'WordPress';
+
+    private ?Settings $renderer = null;
+
+    public function init(): void
+    {
+        if (!MailSenderService::isEnabled()) {
+            return;
+        }
+
+        /*
+            Pas de garde sur l'activation de Gravity Forms : FormService::isGravityFormsActive()
+            repose sur is_plugin_active(), absente en contexte WP-CLI, ce qui rendrait les filtres
+            invisibles aux scripts de vérification tout en fonctionnant en front. Un add_filter sur
+            un hook qui ne se déclenche jamais ne coûte rien.
+        */
+        add_filter('gform_notification', [$this, 'applySender'], 10, 3);
+        add_filter('gform_notification_settings_fields', [$this, 'describeSenderSettings']);
+        add_action('admin_init', [$this, 'registerSettingsPage']);
+
+        if (MailSenderService::appliesToWordPressMails()) {
+            add_filter('wp_mail_from', [$this, 'mailFrom']);
+            add_filter('wp_mail_from_name', [$this, 'mailFromName']);
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $notification
+     * @param  array<string, mixed>  $form
+     * @param  array<string, mixed>|false  $entry
+     * @return array<string, mixed>
+     */
+    public function applySender(array $notification, array $form, $entry): array
+    {
+        $address = MailSenderService::getAddress();
+        $name = MailSenderService::getName();
+
+        if ('' !== $address && $this->isSenderAddressUnset($notification)) {
+            $notification['from'] = $address;
+        }
+
+        if ('' !== $name && '' === $this->setting($notification, 'fromName')) {
+            $notification['fromName'] = $name;
+        }
+
+        if ('' === $this->setting($notification, 'replyTo') && $this->isSentToTeam($notification)) {
+            $visitorEmail = $this->submittedEmail($form, $entry);
+
+            if (null !== $visitorEmail) {
+                $notification['replyTo'] = $visitorEmail;
+            }
+        }
+
+        return $notification;
+    }
+
+    /**
+     * Documente le réglage global sous les trois champs concernés de l'écran d'édition d'une
+     * notification. Sans ça, la personne qui y lit `{admin_email}` reçoit un e-mail signé autrement
+     * sans pouvoir comprendre d'où vient l'écart.
+     *
+     * Les libellés citent la valeur résolue et non sa provenance : le filtre de MailSenderService
+     * permet à un thème de servir ces valeurs depuis sa propre page d'options, auquel cas nommer
+     * l'écran Gravity Forms serait faux.
+     *
+     * @param  array<int, array<string, mixed>>  $sections
+     * @return array<int, array<string, mixed>>
+     */
+    public function describeSenderSettings(array $sections): array
+    {
+        $address = MailSenderService::getAddress();
+        $name = MailSenderService::getName();
+
+        $descriptions = [
+            'from' => '' === $address
+                ? __("Aucune adresse d'expéditeur globale n'est définie : ce champ fait foi.", 'horizon-tools')
+                : sprintf(
+                    /* translators: 1: merge tag laissé par défaut, 2: adresse d'expéditeur globale. */
+                    __(
+                        'Laissé sur <code>%1$s</code>, ce champ suit l\'expéditeur global du site, soit '
+                            . '<strong>%2$s</strong>. Saisissez une adresse pour ne changer que cette notification.',
+                        'horizon-tools',
+                    ),
+                    esc_html(self::GF_DEFAULT_FROM),
+                    esc_html($address),
+                ),
+            'fromName' => '' === $name
+                ? __(
+                    "Aucun nom d'expéditeur global n'est défini : laissé vide, l'e-mail s'affichera sous la "
+                        . "seule adresse d'expéditeur.",
+                    'horizon-tools',
+                )
+                : sprintf(
+                    /* translators: %s: nom d'expéditeur global. */
+                    __("Laissé vide, ce champ suit le nom d'expéditeur global du site, soit <strong>%s</strong>.", 'horizon-tools'),
+                    esc_html($name),
+                ),
+            'replyTo' => __(
+                "Laissé vide sur une notification adressée à l'équipe, la réponse est dirigée vers l'adresse "
+                    . 'saisie par le visiteur dans le formulaire.',
+                'horizon-tools',
+            ),
+        ];
+
+        foreach ($sections as $sectionIndex => $section) {
+            foreach ($section['fields'] ?? [] as $fieldIndex => $field) {
+                $fieldName = $field['name'] ?? '';
+
+                // On ne remplace pas une description que Gravity Forms ou une extension aurait déjà posée.
+                if (!isset($descriptions[$fieldName]) || isset($field['description'])) {
+                    continue;
+                }
+
+                $sections[$sectionIndex]['fields'][$fieldIndex]['description'] = $descriptions[$fieldName];
+            }
+        }
+
+        return $sections;
+    }
+
+    /**
+     * WordPress applique ce filtre après avoir lu l'en-tête `From` fourni par l'appelant, et sans
+     * distinguer les deux cas (pluggable.php). Écraser sans condition annulerait donc l'expéditeur
+     * que Gravity Forms vient de calculer, et avec lui toute surcharge par notification : on ne se
+     * substitue qu'à l'adresse de repli de WordPress.
+     */
+    public function mailFrom(string $from): string
+    {
+        $address = MailSenderService::getAddress();
+
+        if ('' === $address || $from !== $this->wordPressFallbackAddress()) {
+            return $from;
+        }
+
+        return $address;
+    }
+
+    /** Même raisonnement que mailFrom() : on ne remplace que le nom de repli de WordPress. */
+    public function mailFromName(string $fromName): string
+    {
+        $name = MailSenderService::getName();
+
+        if ('' === $name || self::WP_DEFAULT_FROM_NAME !== $fromName) {
+            return $fromName;
+        }
+
+        return $name;
+    }
+
+    /**
+     * Déclare l'onglet « E-mails » sous Formulaires > Réglages. L'enregistrement est traité ici, et
+     * non au rendu : Gravity Forms appelle le gestionnaire de la sous-vue après avoir écrit l'en-tête
+     * de page, trop tard pour un message de confirmation ou une redirection.
+     */
+    public function registerSettingsPage(): void
+    {
+        if (!class_exists(\GFForms::class) || !class_exists(Settings::class)) {
+            return;
+        }
+
+        \GFForms::add_settings_page([
+            'name' => self::SETTINGS_SUBVIEW,
+            'tab_label' => __('E-mails', 'horizon-tools'),
+            'title' => __("Expéditeur des e-mails", 'horizon-tools'),
+            'icon' => 'gform-icon--mail',
+            'handler' => [$this, 'renderSettingsPage'],
+        ]);
+
+        if (self::SETTINGS_SUBVIEW !== rgget('subview')) {
+            return;
+        }
+
+        $renderer = $this->settingsRenderer();
+
+        if ($renderer->is_save_postback()) {
+            $renderer->process_postback();
+        }
+    }
+
+    public function renderSettingsPage(): void
+    {
+        wp_enqueue_style('gform_admin');
+
+        $this->settingsRenderer()->render();
+    }
+
+    private function settingsRenderer(): Settings
+    {
+        if (null !== $this->renderer) {
+            return $this->renderer;
+        }
+
+        return $this->renderer = new Settings([
+            'capability' => 'gravityforms_edit_settings',
+            'input_name_prefix' => '_horizon_mail_sender',
+            // Chaîne et non tableau : le lecteur d'option est déduit du nom, l'écriture reste à
+            // notre charge dès qu'un save_callback est fourni (class-settings.php, save_values()).
+            'initial_values' => MailSenderService::OPTION_NAME,
+            'save_callback' => static function ($values): void {
+                update_option(MailSenderService::OPTION_NAME, $values);
+                MailSenderService::flushCache();
+            },
+            'fields' => [
+                [
+                    'id' => 'horizon-mail-sender',
+                    'title' => __("Expéditeur des e-mails", 'horizon-tools'),
+                    'description' => __(
+                        'Ces deux valeurs servent de défaut à toutes les notifications de formulaire et à tous '
+                            . 'les e-mails envoyés par WordPress. Une notification qui définit son propre '
+                            . 'expéditeur garde le sien.',
+                        'horizon-tools',
+                    ),
+                    'class' => 'gform-settings-panel--full',
+                    'fields' => [
+                        [
+                            'name' => MailSenderService::SETTING_ADDRESS,
+                            'label' => __("Adresse d'expéditeur", 'horizon-tools'),
+                            'type' => 'text',
+                            'description' => __(
+                                'Utilisez une adresse du domaine du site, sans quoi les e-mails risquent '
+                                    . "d'être classés en indésirables. Laissée vide, chaque notification garde "
+                                    . 'son propre réglage.',
+                                'horizon-tools',
+                            ),
+                            'validation_callback' => static function ($field, $value): void {
+                                if (!empty($value) && !is_email($value)) {
+                                    $field->set_error(__('Veuillez saisir une adresse e-mail valide.', 'horizon-tools'));
+                                }
+                            },
+                        ],
+                        [
+                            'name' => MailSenderService::SETTING_NAME,
+                            'label' => __("Nom d'expéditeur", 'horizon-tools'),
+                            'type' => 'text',
+                            'description' => __(
+                                "Libellé affiché à la place de l'adresse dans la boîte de réception du destinataire.",
+                                'horizon-tools',
+                            ),
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    /** @param array<string, mixed> $notification */
+    private function isSenderAddressUnset(array $notification): bool
+    {
+        $from = $this->setting($notification, 'from');
+
+        return '' === $from || self::GF_DEFAULT_FROM === $from;
+    }
+
+    /**
+     * Distingue les notifications destinées à l'équipe de celles destinées au visiteur. `toType`
+     * vaut `field` quand le destinataire est un champ du formulaire, donc le visiteur lui-même ;
+     * `email` et `routing` désignent des adresses fixes, donc l'équipe.
+     *
+     * @param  array<string, mixed>  $notification
+     */
+    private function isSentToTeam(array $notification): bool
+    {
+        return 'field' !== $this->setting($notification, 'toType');
+    }
+
+    /**
+     * Adresse saisie par le visiteur, prise dans le premier champ e-mail du formulaire. Repérée par
+     * type et non par identifiant, pour rester valable sur n'importe quel formulaire.
+     *
+     * @param  array<string, mixed>  $form
+     * @param  array<string, mixed>|false  $entry
+     */
+    private function submittedEmail(array $form, $entry): ?string
+    {
+        if (!is_array($entry)) {
+            return null;
+        }
+
+        foreach ($form['fields'] ?? [] as $field) {
+            if (!$field instanceof \GF_Field || 'email' !== $field->get_input_type()) {
+                continue;
+            }
+
+            $value = trim((string) ($entry[(string) $field->id] ?? ''));
+
+            if (is_email($value)) {
+                return $value;
+            }
+        }
+
+        return null;
+    }
+
+    /** Reproduit le repli `wordpress@<domaine>` de wp_mail() (pluggable.php). */
+    private function wordPressFallbackAddress(): string
+    {
+        $host = wp_parse_url(network_home_url(), PHP_URL_HOST);
+
+        if (!is_string($host)) {
+            return 'wordpress@';
+        }
+
+        if (str_starts_with($host, 'www.')) {
+            $host = substr($host, 4);
+        }
+
+        return 'wordpress@' . $host;
+    }
+
+    /** @param array<string, mixed> $notification */
+    private function setting(array $notification, string $key): string
+    {
+        return trim((string) ($notification[$key] ?? ''));
+    }
+}

--- a/src/Providers/HooksServiceProvider.php
+++ b/src/Providers/HooksServiceProvider.php
@@ -10,6 +10,7 @@ use Adeliom\HorizonTools\Hooks\DefaultBackOfficeHooks;
 use Adeliom\HorizonTools\Hooks\DefaultCompilationHooks;
 use Adeliom\HorizonTools\Hooks\DefaultGravityFormsHooks;
 use Adeliom\HorizonTools\Hooks\DefaultGutenbergHooks;
+use Adeliom\HorizonTools\Hooks\DefaultMailSenderHooks;
 use Adeliom\HorizonTools\Hooks\DefaultTaxonomyHooks;
 use Adeliom\HorizonTools\Hooks\DefaultWordPressHooks;
 use Adeliom\HorizonTools\Hooks\PostHooks;
@@ -44,6 +45,7 @@ class HooksServiceProvider extends SageServiceProvider
                 DefaultCompilationHooks::class,
                 DefaultAcfHooks::class,
                 DefaultGravityFormsHooks::class,
+                DefaultMailSenderHooks::class,
                 WysiwygHooks::class,
                 QueryBuilderHooks::class,
                 DefaultTaxonomyHooks::class,

--- a/src/Services/MailSenderService.php
+++ b/src/Services/MailSenderService.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Adeliom\HorizonTools\Services;
+
+use Illuminate\Support\Facades\Config;
+
+/**
+ * Expéditeur commun à tous les e-mails du site, défini une fois au lieu d'être répété dans chaque
+ * notification Gravity Forms.
+ *
+ * La fonctionnalité est désactivée par défaut : `gravityforms.sender.enabled` doit être passé à true
+ * dans le `config/gravityforms.php` du thème. Sans ce garde-fou, une simple mise à jour du paquet
+ * changerait l'expéditeur des projets qui s'appuient sur des adresses définies par notification.
+ *
+ * Le réglage se saisit dans Formulaires > Réglages > E-mails, et non dans une page d'options ACF,
+ * pour que la fonctionnalité ne dépende ni d'ACF ni de la structure du back-office du thème. Un
+ * thème qui préfère sa propre interface passe par le filtre self::FILTER.
+ */
+class MailSenderService
+{
+    /** Option unique où l'écran de réglages Gravity Forms enregistre les deux valeurs. */
+    public const OPTION_NAME = 'horizon_tools_mail_sender';
+
+    public const SETTING_ADDRESS = 'senderAddress';
+    public const SETTING_NAME = 'senderName';
+
+    /**
+     * Filtre du couple adresse / nom résolu, appliqué après lecture de l'option.
+     *
+     * Reçoit et doit retourner un tableau `['address' => string, 'name' => string]`. Une adresse
+     * invalide est ignorée. C'est le point d'entrée d'un thème qui veut piloter l'expéditeur depuis
+     * sa propre page d'options plutôt que depuis l'écran Gravity Forms.
+     */
+    public const FILTER = 'horizon_tools_mail_sender';
+
+    /** @var array{address: string, name: string}|null */
+    private static ?array $resolved = null;
+
+    public static function isEnabled(): bool
+    {
+        return (bool) (Config::get('gravityforms.sender.enabled') ?? false);
+    }
+
+    /**
+     * Les e-mails hors Gravity Forms (réinitialisation de mot de passe, alertes WordPress) suivent
+     * le même expéditeur, sauf si le projet préfère limiter la fonctionnalité aux formulaires.
+     */
+    public static function appliesToWordPressMails(): bool
+    {
+        return (bool) (Config::get('gravityforms.sender.applyToWordPressMails') ?? true);
+    }
+
+    public static function getAddress(): string
+    {
+        return self::resolve()['address'];
+    }
+
+    public static function getName(): string
+    {
+        return self::resolve()['name'];
+    }
+
+    /**
+     * À appeler après toute écriture de l'option, sans quoi la même requête continuerait de servir
+     * la valeur précédente — l'écran de réglages afficherait l'ancien expéditeur juste après
+     * l'enregistrement.
+     */
+    public static function flushCache(): void
+    {
+        self::$resolved = null;
+    }
+
+    /** @return array{address: string, name: string} */
+    private static function resolve(): array
+    {
+        if (null !== self::$resolved) {
+            return self::$resolved;
+        }
+
+        $stored = get_option(self::OPTION_NAME, []);
+        $stored = is_array($stored) ? $stored : [];
+
+        $sender = apply_filters(self::FILTER, [
+            'address' => trim((string) ($stored[self::SETTING_ADDRESS] ?? '')),
+            'name' => trim((string) ($stored[self::SETTING_NAME] ?? '')),
+        ]);
+
+        $sender = is_array($sender) ? $sender : [];
+        $address = trim((string) ($sender['address'] ?? ''));
+
+        return self::$resolved = [
+            // Une adresse invalide ferait échouer l'envoi : mieux vaut ignorer le réglage que
+            // casser toutes les notifications du site.
+            'address' => is_email($address) ? $address : '',
+            'name' => trim((string) ($sender['name'] ?? '')),
+        ];
+    }
+}


### PR DESCRIPTION
## Pourquoi

L'adresse d'expéditeur est la même dans toutes les notifications Gravity Forms d'un projet, mais elle se saisit notification par notification. Sur Vénus : 5 formulaires × 2 notifications = 10 endroits à modifier pour un changement d'adresse.

Point noir moins visible : le champ **From Name** est vide par défaut. GF envoie alors l'en-tête `From` sans libellé (`common.php:2403`), donc les e-mails s'affichent sous l'adresse brute au lieu du nom du client.

## Ce que fait la PR

Une adresse et un nom d'expéditeur saisis une fois dans **Formulaires > Réglages > E-mails** servent de défaut à toutes les notifications Gravity Forms et à tous les e-mails de WordPress.

- `src/Services/MailSenderService.php` — résout le couple adresse / nom (option, filtre, validation)
- `src/Hooks/DefaultMailSenderHooks.php` — applique l'expéditeur et porte l'écran de saisie
- `HooksServiceProvider` + section de README

Volontairement pas une page d'options ACF : la fonctionnalité ne dépend ni d'ACF ni de la structure du back-office du thème.

## Un défaut, jamais une contrainte

Le réglage ne remplit que les champs laissés vides, **ou** laissés sur le `{admin_email}` que GF y place lui-même (`notification.php:378`). Une adresse saisie dans une notification l'emporte donc toujours : la surcharge par formulaire se fait dans l'UI Gravity Forms.

Corollaire assumé : `{admin_email}` est indissociable de « non renseigné ». Pour qu'une notification suive explicitement l'adresse d'administration du site malgré un réglage global, il faut y écrire l'adresse en clair.

Une description sous chacun des trois champs concernés (From Email, From Name, Reply To) affiche la valeur globale résolue et rappelle qu'on peut la surcharger — sans ça, la personne qui lit `{admin_email}` en back-office reçoit un e-mail signé autrement sans pouvoir comprendre l'écart.

## Reply-To

Même règle : rempli seulement s'il est vide, avec l'adresse saisie par le visiteur, et **uniquement sur les notifications adressées à l'équipe**. Le discriminant est `toType` : `field` = destinataire pris dans un champ du formulaire, donc le visiteur (on ne touche pas) ; `email` et `routing` = adresses fixes. L'adresse du visiteur est repérée par le premier champ de type e-mail, pas par un identifiant en dur.

## Le piège de `wp_mail_from`

WordPress applique `wp_mail_from` **après** avoir lu l'en-tête `From` fourni par l'appelant, et sans distinguer les deux cas (`pluggable.php:437`). Un filtre naïf aurait écrasé l'expéditeur calculé par Gravity Forms, et annulé toute surcharge par notification.

Le hook ne se substitue qu'au repli `wordpress@<domaine>` / `WordPress`.

## Activation

Désactivé par défaut. Le paquet est partagé : sans ce garde-fou, un `composer update` changerait silencieusement l'expéditeur des projets qui s'appuient sur des adresses définies par notification.

```php
// config/gravityforms.php
return [
    'sender' => [
        'enabled' => true,
        // false pour laisser les e-mails hors Gravity Forms tranquilles
        'applyToWordPressMails' => true,
    ],
];
```

## Filtre d'échappement

L'écran Gravity Forms est moins trouvable pour un client qu'un onglet dans les Paramètres d'un back-office français. Un projet qui préfère sa propre interface répond au filtre `horizon_tools_mail_sender` :

```php
add_filter('horizon_tools_mail_sender', fn (array $sender): array => [
    'address' => get_field('sender_address', 'option') ?: $sender['address'],
    'name' => get_field('sender_name', 'option') ?: $sender['name'],
]);
```

## Vérifications

Sur Vénus, paquet placé temporairement dans `vendor/` :

| Cas | Résultat |
| --- | --- |
| Réglage vide | `from` et `fromName` inchangés sur les 10 notifications |
| Réglage rempli | les 10 suivent l'adresse et le nom globaux |
| Notification avec sa propre adresse | elle gagne |
| Merge tag autre que `{admin_email}` (`{Email:4}`) | conservé |
| Accusé de réception (`toType=field`) | `replyTo` laissé vide |
| Notification administrateur | `replyTo` = e-mail du prospect |
| Adresse invalide dans le réglage | ignorée, aucun envoi cassé |
| Filtre `horizon_tools_mail_sender` | reprend la main sur les deux valeurs |

Écran de réglages chargé en session administrateur : onglet présent dans la navigation, champs rendus, aucune erreur PHP, enregistrement persisté dans l'option `horizon_tools_mail_sender`, validation qui refuse une adresse invalide sans écraser la valeur en base.

Écran d'édition de notification chargé : les trois descriptions s'affichent avec la valeur résolue.

Envoi réel via Mailpit : `From: Abridéal <contact@abrideal.fr>` sur les deux notifications, `Reply-To: prospect@exemple.fr` sur la seule notification équipe.

## Notes

- Pas de constantes typées : elles exigent PHP 8.3 alors que le paquet déclare `>=8.2`.
- Prettier n'a pas été passé (`node_modules` absent du dépôt). Lignes sous 140, indentation à 4 espaces.
- À suivre : ajouter la clé `sender` à `false` dans le `config/gravityforms.php` de `horizon-starter`, pour rendre la fonctionnalité découvrable sur les nouveaux projets.